### PR TITLE
Remove TMDB key from frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,7 +18,7 @@ def home():
     url = f"https://api.themoviedb.org/3/trending/movie/week?api_key={TMDB_API_KEY}&page=1"
     response = requests.get(url).json()
     movies = response.get("results", [])
-    return render_template("index.html", movies=movies, TMDB_API_KEY=TMDB_API_KEY)
+    return render_template("index.html", movies=movies)
 
 
 # Movie Details Page

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,9 +42,6 @@
     <div id="loading" class="loading">Loading more movies...</div>
   </main>
 
-  <script>
-    const TMDB_API_KEY = "{{ TMDB_API_KEY }}"; // Passed from Flask
-  </script>
   <script src="/static/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid exposing TMDB API key in `index.html`
- update backend home route accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880b8dd6c48321ba429e9a9b67774f