### PR TITLE
Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 requests
 python-dotenv
+sentence-transformers
+scikit-learn


### PR DESCRIPTION
## Summary
- include `sentence-transformers` and `scikit-learn` in the requirements file

## Testing
- `pip install -r requirements.txt` *(fails: Could not install packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68880b8bb87c832182670b7382419bed