### PR TITLE
Implement search and keep TMDb key server-side

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,7 +18,7 @@ def home():
     url = f"https://api.themoviedb.org/3/trending/movie/week?api_key={TMDB_API_KEY}&page=1"
     response = requests.get(url).json()
     movies = response.get("results", [])
-    return render_template("index.html", movies=movies, TMDB_API_KEY=TMDB_API_KEY)
+    return render_template("index.html", movies=movies)
 
 
 # Movie Details Page
@@ -45,6 +45,21 @@ def movie_details(movie_id):
 def load_more():
     page = request.args.get("page", 1)
     url = f"https://api.themoviedb.org/3/trending/movie/week?api_key={TMDB_API_KEY}&page={page}"
+    response = requests.get(url).json()
+    return {"movies": response.get("results", [])}
+
+
+# Search Movies Route
+@app.route("/search")
+def search():
+    query = request.args.get("query", "")
+    if not query:
+        return {"movies": []}
+
+    url = (
+        f"https://api.themoviedb.org/3/search/movie?api_key={TMDB_API_KEY}"
+        f"&query={requests.utils.quote(query)}"
+    )
     response = requests.get(url).json()
     return {"movies": response.get("results", [])}
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,6 +1,9 @@
 let page = 1; // Pagination
+let isSearching = false; // Track if search results are displayed
 const container = document.getElementById("movie-container");
 const loading = document.getElementById("loading");
+const searchForm = document.getElementById("search-form");
+const searchInput = searchForm ? searchForm.querySelector("input") : null;
 
 // Animate cards when visible and scale center card
 function animateCards() {
@@ -24,6 +27,7 @@ function animateCards() {
 
 // Infinite scroll loading
 async function loadMoreMovies() {
+  if (isSearching) return;
   loading.style.display = "block";
   page++;
   const response = await fetch(`/load_more?page=${page}`);
@@ -56,6 +60,37 @@ window.addEventListener("scroll", () => {
     loadMoreMovies();
   }
 });
+
+// Search handling
+if (searchForm) {
+  searchForm.addEventListener("submit", async e => {
+    e.preventDefault();
+    const query = searchInput.value.trim();
+    if (!query) return;
+    page = 1;
+    isSearching = true;
+    loading.style.display = "block";
+    const response = await fetch(`/search?query=${encodeURIComponent(query)}`);
+    const data = await response.json();
+    container.innerHTML = "";
+    data.movies.forEach(movie => {
+      const card = document.createElement("div");
+      card.className = "movie-card";
+      card.innerHTML = `
+        <a href="/movie/${movie.id}">
+          <img src="https://image.tmdb.org/t/p/w300${movie.poster_path}" alt="${movie.title}">
+        </a>
+        <div class="movie-info">
+          <h3>${movie.title}</h3>
+          <p>⭐ ${movie.vote_average}</p>
+        </div>
+      `;
+      container.appendChild(card);
+    });
+    loading.style.display = "none";
+    animateCards();
+  });
+}
 
 // Initial animation
 animateCards();

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,10 +17,10 @@
       <li><a href="#">Series</a></li>
       <li><a href="#">Regions</a></li>
     </ul>
-    <div class="search-box">
+    <form id="search-form" class="search-box">
       <input type="text" placeholder="Search movies, shows..." />
-      <button>🔍</button>
-    </div>
+      <button type="submit">🔍</button>
+    </form>
   </nav>
 
   <!-- Main Section -->
@@ -42,9 +42,6 @@
     <div id="loading" class="loading">Loading more movies...</div>
   </main>
 
-  <script>
-    const TMDB_API_KEY = "{{ TMDB_API_KEY }}"; // Passed from Flask
-  </script>
   <script src="/static/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a `/search` route for TMDb queries
- remove exposure of `TMDB_API_KEY` in HTML
- hook up search form in JavaScript and reset pagination

## Testing
- `python -m py_compile backend/app.py && node -c static/js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68880b8ab5ec832181d49c67407037e9