### PR TITLE
Add semantic similarity recommender

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request
 import requests
 import os
 from dotenv import load_dotenv
+from recommender import MovieRecommender
 
 # Load environment variables
 load_dotenv()
@@ -10,6 +11,7 @@ app = Flask(__name__, template_folder="../templates", static_folder="../static")
 
 # TMDB API Key
 TMDB_API_KEY = os.getenv("TMDB_API_KEY")
+recommender = MovieRecommender(TMDB_API_KEY)
 
 
 # Home Route - Trending Movies
@@ -37,7 +39,13 @@ def movie_details(movie_id):
             trailer_key = video["key"]
             break
 
-    return render_template("movie.html", movie=movie_data, trailer_key=trailer_key)
+    recommendations = recommender.get_recommendations(movie_id)
+    return render_template(
+        "movie.html",
+        movie=movie_data,
+        trailer_key=trailer_key,
+        recommendations=recommendations,
+    )
 
 
 # Infinite Scroll - Load More Movies

--- a/backend/recommender.py
+++ b/backend/recommender.py
@@ -1,0 +1,67 @@
+from sentence_transformers import SentenceTransformer
+from sklearn.metrics.pairwise import cosine_similarity
+import requests
+
+
+class MovieRecommender:
+    """Simple semantic similarity-based movie recommender."""
+
+    _model = None
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        if MovieRecommender._model is None:
+            MovieRecommender._model = SentenceTransformer("all-MiniLM-L6-v2")
+        self.model = MovieRecommender._model
+        self.overview_cache: dict[int, str] = {}
+
+    def _get_movie_overview(self, movie_id: int) -> str:
+        """Return the overview for a movie, caching the result."""
+        if movie_id not in self.overview_cache:
+            url = f"https://api.themoviedb.org/3/movie/{movie_id}?api_key={self.api_key}"
+            data = requests.get(url).json()
+            overview = data.get("overview", "")
+            self.overview_cache[movie_id] = overview or ""
+        return self.overview_cache[movie_id]
+
+    def _get_trending_movies(self):
+        """Fetch trending movies and store their overviews in the cache."""
+        url = f"https://api.themoviedb.org/3/trending/movie/week?api_key={self.api_key}&page=1"
+        data = requests.get(url).json()
+        movies = data.get("results", [])
+        for movie in movies:
+            if movie.get("overview"):
+                self.overview_cache[movie["id"]] = movie["overview"]
+        return movies
+
+    def get_recommendations(self, movie_id: int, count: int = 5):
+        """Return a list of recommended movies based on overview similarity."""
+        trending = self._get_trending_movies()
+        target_overview = self._get_movie_overview(movie_id)
+        if not target_overview:
+            return []
+
+        overviews = [target_overview]
+        for m in trending:
+            overviews.append(self._get_movie_overview(m["id"]))
+
+        embeddings = self.model.encode(overviews)
+        target_emb = embeddings[0]
+        other_embs = embeddings[1:]
+
+        sims = cosine_similarity([target_emb], other_embs)[0]
+        scored = [
+            (sim, m)
+            for sim, m in zip(sims, trending)
+            if m["id"] != movie_id
+        ]
+        scored.sort(reverse=True, key=lambda x: x[0])
+        recommendations = [
+            {
+                "id": m["id"],
+                "title": m["title"],
+                "poster_path": m.get("poster_path"),
+            }
+            for sim, m in scored[:count]
+        ]
+        return recommendations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 requests
 python-dotenv
+sentence-transformers
+scikit-learn

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -125,3 +125,16 @@ main {
   padding: 20px;
   display: none;
 }
+
+/* Recommendations */
+.recommendations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.recommendations .movie-card {
+  width: 150px;
+}

--- a/templates/movie.html
+++ b/templates/movie.html
@@ -32,6 +32,18 @@
     {% else %}
       <p>No reviews available.</p>
     {% endif %}
+
+    <h2>Recommended Movies</h2>
+    <div class="recommendations">
+      {% for rec in recommendations %}
+        <div class="movie-card">
+          <a href="/movie/{{ rec.id }}">
+            <img src="https://image.tmdb.org/t/p/w200{{ rec.poster_path }}" alt="{{ rec.title }}">
+          </a>
+          <p>{{ rec.title }}</p>
+        </div>
+      {% endfor %}
+    </div>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build a simple semantic similarity recommender using sentence-transformers
- add `MovieRecommender` class and expose recommendations in `movie_details`
- display recommended movies in the template
- style recommendations section and add new dependencies

## Testing
- `python -m py_compile backend/*.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68880b888e9083218c291874e7cfee1b