### PR TITLE
Add pytest config and endpoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ python backend/app.py
 
 Visit `http://127.0.0.1:5000` to view the site.
 
+## Running Tests
+
+Install the dependencies and execute `pytest` from the repository root:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
 ## AI Model
 
 WatchNextAI currently uses basic trending data from TMDb. A small collaborative filtering model is planned for personalized recommendations but is limited by the available dataset and is not yet fully featured.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 python-dotenv
 sentence-transformers
 scikit-learn
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,69 @@
+import json
+import types
+import pytest
+
+from backend.app import app
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+def fake_get(url, *args, **kwargs):
+    if 'trending/movie/week' in url:
+        return FakeResponse({"results": [{"id": 1, "title": "Movie 1", "poster_path": "/a.jpg", "vote_average": 8}]})
+    if 'search/movie' in url:
+        return FakeResponse({"results": [{"id": 2, "title": "Search Movie", "poster_path": "/b.jpg", "vote_average": 7}]})
+    if '/movie/' in url and 'recommendations' in url:
+        return FakeResponse({"results": [{"id": 3, "title": "Recommended", "poster_path": "/c.jpg"}]})
+    if '/movie/' in url and 'append_to_response' in url:
+        return FakeResponse({
+            "id": 1,
+            "title": "Movie 1",
+            "overview": "Desc",
+            "vote_average": 8,
+            "videos": {"results": [{"type": "Trailer", "site": "YouTube", "key": "abc"}]},
+            "reviews": {"results": []}
+        })
+    return FakeResponse({})
+
+
+@pytest.fixture(autouse=True)
+def patch_requests(monkeypatch):
+    monkeypatch.setattr('backend.app.requests.get', fake_get)
+    monkeypatch.setattr('backend.recommender.requests.get', fake_get)
+    yield
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_home_page(client):
+    res = client.get('/')
+    assert res.status_code == 200
+    assert b'<html' in res.data
+
+def test_load_more(client):
+    res = client.get('/load_more?page=2')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert 'movies' in data
+    assert isinstance(data['movies'], list)
+
+
+def test_search(client):
+    res = client.get('/search?query=test')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert 'movies' in data
+
+
+def test_movie_details(client):
+    res = client.get('/movie/1')
+    assert res.status_code == 200
+    assert b'<html' in res.data


### PR DESCRIPTION
## Summary
- add pytest configuration and dependencies
- implement tests covering main endpoints using patched API responses
- document how to run the test suite

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888131b201083218184ed978a35a88a