### PR TITLE
feat: ratings on cast/filmography cards, fix duplicate email signup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -303,7 +303,8 @@ def get_movie_credits(movie_id):
     if err:
         return jsonify({"error": err}), 502
     cast = [
-        {"id": m.get("id"), "name": m.get("name"), "character": m.get("character"), "profile_path": m.get("profile_path")}
+        {"id": m.get("id"), "name": m.get("name"), "character": m.get("character"),
+         "profile_path": m.get("profile_path"), "popularity": round(m.get("popularity", 0), 1)}
         for m in (data or {}).get("cast", [])[:8]
     ]
     return jsonify({"cast": cast})
@@ -314,7 +315,8 @@ def get_tv_credits(tv_id):
     if err:
         return jsonify({"error": err}), 502
     cast = [
-        {"id": m.get("id"), "name": m.get("name"), "character": m.get("character"), "profile_path": m.get("profile_path")}
+        {"id": m.get("id"), "name": m.get("name"), "character": m.get("character"),
+         "profile_path": m.get("profile_path"), "popularity": round(m.get("popularity", 0), 1)}
         for m in (data or {}).get("cast", [])[:8]
     ]
     return jsonify({"cast": cast})
@@ -736,7 +738,21 @@ def get_person_credits(person_id):
         key=lambda x: x.get("popularity", 0),
         reverse=True
     )[:24]
-    return jsonify({"cast": cast})
+    trimmed = [
+        {
+            "id": c.get("id"),
+            "title": c.get("title") or c.get("name"),
+            "media_type": c.get("media_type"),
+            "poster_path": c.get("poster_path"),
+            "character": c.get("character"),
+            "job": c.get("job"),
+            "release_date": c.get("release_date") or c.get("first_air_date"),
+            "vote_average": round(c.get("vote_average", 0), 1),
+            "vote_count": c.get("vote_count", 0),
+        }
+        for c in cast
+    ]
+    return jsonify({"cast": trimmed})
 
 
 # ── Movie / TV credits — now include person id ──────────────────────────────────

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1533,3 +1533,7 @@ html[data-theme="light"] .dynamic-bg {
 .person-card:hover img { transform: scale(1.04); }
 .person-card-title { font-size: .73rem; font-weight: 600; margin: .35rem 0 .15rem; }
 .person-card-sub { font-size: .67rem; color: var(--fg-muted); }
+
+/* ===== Cast popularity + person card rating ===== */
+.cast-pop { display: block; font-size: .62rem; color: var(--fg-muted); margin-top: .15rem; }
+.person-card-rating { color: #f59e0b; font-size: .65rem; font-weight: 700; }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -31,14 +31,18 @@ async function signUp(email, password, displayName) {
 
     if (error) {
         console.error('Sign up error:', error);
+        // Supabase returns user_already_exists when email confirmation is off
+        if (error.code === 'user_already_exists' || error.message?.toLowerCase().includes('already registered')) {
+            return { success: false, error: 'This email is already registered. Please sign in instead.' };
+        }
         const msg = error.message === 'Failed to fetch'
             ? 'Cannot reach auth server. Check your internet connection or try again later.'
             : error.message;
         return { success: false, error: msg };
     }
 
-    // Empty identities = email already registered (Supabase behaviour when confirm is on)
-    if (data.user?.identities?.length === 0) {
+    // Empty identities = email already registered (Supabase behaviour when email confirmation is on)
+    if (!data.user || data.user?.identities?.length === 0) {
         return { success: false, error: 'This email is already registered. Please sign in instead.' };
     }
 

--- a/templates/movie_detail.html
+++ b/templates/movie_detail.html
@@ -306,7 +306,8 @@
                     const el = document.createElement('a');
                     el.className = 'cast-card';
                     el.href = m.id ? `/person/${m.id}` : '#';
-                    el.innerHTML = `<img class="cast-avatar" src="${img}" alt="${m.name||''}" loading="lazy"><p class="cast-name">${m.name||''}</p><p class="cast-character">${m.character||''}</p>`;
+                    const pop = m.popularity >= 5 ? `<span class="cast-pop">🔥 ${Math.round(m.popularity)}</span>` : '';
+                    el.innerHTML = `<img class="cast-avatar" src="${img}" alt="${m.name||''}" loading="lazy"><p class="cast-name">${m.name||''}</p><p class="cast-character">${m.character||''}</p>${pop}`;
                     grid.appendChild(el);
                 });
                 document.getElementById('castSection').style.display = 'block';

--- a/templates/person_detail.html
+++ b/templates/person_detail.html
@@ -159,9 +159,11 @@
                                 ? `https://image.tmdb.org/t/p/w185${c.poster_path}`
                                 : 'https://via.placeholder.com/115x172?text=No+Image';
                             const title = c.title || c.name || 'Untitled';
-                            const year = (c.release_date || c.first_air_date || '').slice(0,4);
+                            const year = (c.release_date || '').slice(0,4);
                             const role = c.character || c.job || '';
-                            a.innerHTML = `<img src="${poster}" alt="${title}" loading="lazy" /><div class="person-card-title">${title}</div><div class="person-card-sub">${role}${role && year ? ' · ' : ''}${year}</div>`;
+                            const rating = c.vote_average && c.vote_average > 0 && c.vote_count > 10
+                                ? `<span class="person-card-rating">⭐ ${c.vote_average.toFixed(1)}</span>` : '';
+                            a.innerHTML = `<img src="${poster}" alt="${title}" loading="lazy" /><div class="person-card-title">${title}</div><div class="person-card-sub">${role}${role && year ? ' · ' : ''}${year}${rating ? ' ' : ''}${rating}</div>`;
                             grid.appendChild(a);
                         });
                         document.getElementById('personFilmography').style.display = 'block';

--- a/templates/tv_detail.html
+++ b/templates/tv_detail.html
@@ -415,7 +415,8 @@
                     const el = document.createElement('a');
                     el.className = 'cast-card';
                     el.href = m.id ? `/person/${m.id}` : '#';
-                    el.innerHTML = `<img class="cast-avatar" src="${img}" alt="${m.name||''}" loading="lazy"><p class="cast-name">${m.name||''}</p><p class="cast-character">${m.character||''}</p>`;
+                    const pop = m.popularity >= 5 ? `<span class="cast-pop">🔥 ${Math.round(m.popularity)}</span>` : '';
+                    el.innerHTML = `<img class="cast-avatar" src="${img}" alt="${m.name||''}" loading="lazy"><p class="cast-name">${m.name||''}</p><p class="cast-character">${m.character||''}</p>${pop}`;
                     grid.appendChild(el);
                 });
                 document.getElementById('castSection').style.display = 'block';


### PR DESCRIPTION
## Summary

- **Issue #14 — Ratings next to cast names**
  - Person filmography cards now show TMDB `vote_average` rating (⭐ X.X) for each title, only when `vote_count > 10` (avoids noisy/unreliable scores)
  - Cast cards on movie & TV detail pages show actor popularity score (🔥 N) for notable actors (popularity ≥ 5)
  - Person credits API endpoint trimmed to return only needed fields including `vote_average` and `vote_count`

- **Issue #15 — Duplicate email signup**
  - `signUp()` now catches the explicit `user_already_exists` error code Supabase returns when email confirmation is off
  - Also guards against a null `data.user` object
  - Both code paths show the same friendly message: "This email is already registered. Please sign in instead."

## Test plan

- [ ] Open any movie page → cast section → confirm popular actors show a 🔥 score
- [ ] Click a cast member → person page → filmography → confirm ⭐ ratings show on titles with enough votes
- [ ] Try signing up with an already-registered email → confirm "already registered" message appears (not a raw error)

https://claude.ai/code/session_012k6EHZwgAGgs4eAnXz3iQn